### PR TITLE
set a definitive style for genesis

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,24 +1,44 @@
 ---
 Language: Cpp
-BasedOnStyle: LLVM
-AlwaysBreakTemplateDeclarations: Yes
-BreakBeforeBraces: Attach
-ColumnLimit: 160
-SpaceAfterTemplateKeyword: true
-Standard: c++20
-TabWidth: 4
-IndentWidth: 4
-UseTab: Always
+BasedOnStyle: Microsoft
+AccessModifierOffset: -4
+AlignConsecutiveAssignments: Consecutive
+AlignConsecutiveMacros: Consecutive
+AlignEscapedNewlines: Right
+AlignTrailingComments: Always
 AllowShortEnumsOnASingleLine: true
 AllowShortCaseLabelsOnASingleLine: true
-AllowShortFunctionsOnASingleLine: All
+AllowShortFunctionsOnASingleLine: InlineOnly
 AllowShortLambdasOnASingleLine: All
 AllowShortBlocksOnASingleLine: Always
-AllowShortIfStatementsOnASingleLine: Always
+AllowShortIfStatementsOnASingleLine: WithoutElse
 AllowShortLoopsOnASingleLine: true
-IndentRequires: true
-AccessModifierOffset: -4
+AlwaysBreakTemplateDeclarations: Yes
+BraceWrapping:
+    AfterCaseLabel: true
+    AfterClass: true
+    AfterControlStatement: Always
+    AfterEnum: true
+    AfterFunction: true
+    AfterNamespace: true
+    AfterStruct: true
+    AfterUnion: true
+    AfterExternBlock: false
+    BeforeCatch: false
+    BeforeElse: false
+    BeforeLambdaBody: false
+    BeforeWhile: false
+    IndentBraces: true
+    SplitEmptyFunction: true
+    SplitEmptyRecord: true
+    SplitEmptyNamespace: true
+BreakAfterAttributes: Never
+BreakBeforeBraces: Allman
+ColumnLimit: 160
+CompactNamespaces: false
+FixNamespaceComments: true
 IndentPPDirectives: BeforeHash
+IndentWidth: 4
 IncludeCategories:
     # Headers in <> with .h extension.
     - Regex: '<([A-Za-z0-9\/-_])+\.h>'
@@ -29,5 +49,9 @@ IncludeCategories:
     # Headers in <> without extension.
     - Regex: '<([A-Za-z0-9\/-_])+>'
       Priority: 30
-PointerAlignment: Left
-QualifierAlignment: Right
+NamespaceIndentation: All
+PointerAlignment: Middle
+SpaceAfterTemplateKeyword: true
+Standard: c++20
+TabWidth: 4
+UseTab: Always


### PR DESCRIPTION
I've layout a possible formatting style for clang-format. If there are any issues with this formatting rule set, let me know @Kouros26 and @karnkaul .