### PR TITLE
Add tools/code-formatter

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -33,6 +33,7 @@ endif()
 
 option(GENESIS_BUILD_EDITOR "Build the genesis editor (else only library)" ON)
 option(GENESIS_BUILD_SHADERS "Build the genesis shaders" ON)
+option(GENESIS_BUILD_TOOLS "Build Genesis tools" ON)
 
 if(GENESIS_BUILD_EDITOR)
     set(GENESIS_BUILD_SHADERS ON)
@@ -44,4 +45,9 @@ add_subdirectory(engine)
 
 if(GENESIS_BUILD_EDITOR)
   add_subdirectory(editor)
+endif()
+
+
+if (GENESIS_BUILD_TOOLS)
+  add_subdirectory(tools/code-formatter)
 endif()

--- a/engine/include/base/config/compilerTraits.hpp
+++ b/engine/include/base/config/compilerTraits.hpp
@@ -6,6 +6,8 @@
 
 #include "base/config/compiler.hpp"
 
+// clang-format off
+
 // https://learn.microsoft.com/en-us/cpp/intrinsics/compiler-intrinsics?view=msvc-170
 // https://clang.llvm.org/docs/LanguageExtensions.html
 // https://gcc.gnu.org/onlinedocs/gcc-4.8.5/gcc/X86-Built-in-Functions.html

--- a/engine/include/base/config/defines.hpp
+++ b/engine/include/base/config/defines.hpp
@@ -2,6 +2,8 @@
 
 #pragma once
 
+// clang-format off
+
 #ifndef GEN_TRUE
 	#define GEN_TRUE 1
 #endif

--- a/engine/include/base/config/platform.hpp
+++ b/engine/include/base/config/platform.hpp
@@ -2,6 +2,8 @@
 
 #pragma once
 
+// clang-format off
+
 #if (defined(GEN_PLATFORM_WINDOWS) || (defined(_WIN32) || defined(__WIN32__) || defined(_WIN64))) && !defined(CS_UNDEFINED_STRING)
 	#undef GEN_PLATFORM_WINDOWS
 	#define GEN_PLATFORM_WINDOWS 1

--- a/engine/include/system/win32/minWindows.hpp
+++ b/engine/include/system/win32/minWindows.hpp
@@ -2,6 +2,8 @@
 
 #include "core.hpp"
 
+// clang-format off
+
 #if defined(GEN_PLATFORM_WINDOWS)
 
 #if defined(_WINDOWS_) && !defined(GEN_MINIMAL_WINDOWS_INCLUDE)

--- a/engine/include/system/win32/postWinapi.hpp
+++ b/engine/include/system/win32/postWinapi.hpp
@@ -4,6 +4,8 @@
 
 #include "core.hpp"
 
+// clang-format off
+
 #if GEN_PLATFORM_WINDOWS
 
 // Hide Windows-only types (same as HideWindowsPlatformTypes.h)

--- a/engine/include/system/win32/preWinapi.hpp
+++ b/engine/include/system/win32/preWinapi.hpp
@@ -4,6 +4,8 @@
 
 #include "core.hpp"
 
+// clang-format off
+
 #if GEN_PLATFORM_WINDOWS
 
 // Save these macros for later; Windows redefines them

--- a/engine/include/system/win32/windowsHeader.hpp
+++ b/engine/include/system/win32/windowsHeader.hpp
@@ -4,6 +4,8 @@
 
 #include "core.hpp"
 
+// clang-format off
+
 #if GEN_PLATFORM_WINDOWS
 
 #include "system/win32/preWinapi.hpp"

--- a/tools/code-formatter/CMakeLists.txt
+++ b/tools/code-formatter/CMakeLists.txt
@@ -1,0 +1,21 @@
+cmake_minimum_required(VERSION 3.18 FATAL_ERROR)
+
+project(code-formatter)
+
+set(CMAKE_CXX_STANDARD 20)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+set(CMAKE_DEBUG_POSTFIX "-d")
+
+add_executable(${PROJECT_NAME})
+
+set_target_properties(${PROJECT_NAME} PROPERTIES DEBUG_POSTFIX ${CMAKE_DEBUG_POSTFIX})
+
+target_sources(${PROJECT_NAME} PRIVATE
+  main.cpp
+)
+
+if(CMAKE_CXX_COMPILER_ID STREQUAL Clang OR CMAKE_CXX_COMPILER_ID STREQUAL GNU)
+  target_compile_options(${PROJECT_NAME} PRIVATE
+    -Wall -Wextra -Wpedantic -Wconversion -Werror=return-type
+  )
+endif()

--- a/tools/code-formatter/main.cpp
+++ b/tools/code-formatter/main.cpp
@@ -38,7 +38,7 @@ struct Options {
 		}
 
 		if (!unmatched.empty()) {
-			if (unmatched.size() > 1) { throw unexpected_arg(unmatched.front()); }
+			if (unmatched.size() > 1) { throw unexpected_arg(unmatched[1]); }
 			rootDir = unmatched.front();
 		}
 	}

--- a/tools/code-formatter/main.cpp
+++ b/tools/code-formatter/main.cpp
@@ -1,0 +1,155 @@
+#include <algorithm>
+#include <cassert>
+#include <filesystem>
+#include <format>
+#include <iostream>
+#include <mutex>
+#include <span>
+#include <vector>
+
+namespace fs = std::filesystem;
+
+namespace {
+struct Options {
+	struct ParseError : std::runtime_error {
+		using std::runtime_error::runtime_error;
+	};
+	struct Usage {};
+
+	bool quiet{};
+	bool simulate{};
+	std::string_view rootDir{"."};
+
+	static ParseError unexpected_arg(std::string_view const arg) { return ParseError{std::format("unexpected argument: '{}'", arg)}; }
+	static ParseError unrecognized_opt(std::string_view const opt) { return ParseError{std::format("unrecognized option: '{}'", opt)}; }
+
+	static std::string buildUsage(std::string_view const appName) { return std::format("usage: {} [-q|--quiet] [-s|--simulate] [path]", appName); }
+
+	void parse(std::span<char const* const> args) {
+		auto unmatched = std::vector<std::string_view>{};
+		for (std::string_view const arg : args) {
+			if (arg.starts_with("--")) {
+				option(arg.substr(2));
+			} else if (arg.starts_with('-')) {
+				options(arg.substr(1));
+			} else {
+				unmatched.push_back(arg);
+			}
+		}
+
+		if (!unmatched.empty()) {
+			if (unmatched.size() > 1) { throw unexpected_arg(unmatched.front()); }
+			rootDir = unmatched.front();
+		}
+	}
+
+	void option(std::string_view const arg) {
+		if (arg == "quiet") {
+			quiet = true;
+			return;
+		}
+
+		if (arg == "simulate") {
+			simulate = true;
+			return;
+		}
+
+		if (arg == "usage" || arg == "help") { throw Usage{}; }
+
+		throw unrecognized_opt(arg);
+	}
+
+	void options(std::span<char const> opts) {
+		for (char const opt : opts) {
+			switch (opt) {
+			case 'q': quiet = true; break;
+			case 's': simulate = true; break;
+			default: throw unrecognized_opt({&opt, 1});
+			}
+		}
+	}
+};
+
+struct App {
+	static constexpr std::string_view command{"clang-format"};
+	static constexpr std::string_view null_v {
+#if defined(_WIN32)
+		"NUL"
+#else
+		"/dev/null"
+#endif
+	};
+
+	[[nodiscard]] static bool available() {
+		// NOLINTNEXTLINE
+		return std::system(std::format("{} --version > {}", command, null_v).c_str()) == 0;
+	}
+
+	static bool format(std::string_view const path) {
+		if (!fs::is_regular_file(path)) { return false; }
+		// NOLINTNEXTLINE
+		return std::system(std::format("{} -i {}", command, path).c_str()) == 0;
+	}
+
+	std::vector<std::string_view> ignores{"build/", "out/", "ext/", "cmake/"};
+	std::vector<std::string_view> extensions{".hpp", ".cpp"};
+
+	[[nodiscard]] bool shouldIgnore(std::string_view const path) const {
+		return std::ranges::any_of(ignores, [path](std::string_view const ignore) { return path.find(ignore) != std::string_view::npos; });
+	}
+
+	[[nodiscard]] bool shouldFormat(fs::path const& path) const {
+		if (shouldIgnore(path.string())) { return false; }
+		return std::ranges::any_of(extensions, [ext = path.extension()](std::string_view const extension) { return ext == extension; });
+	}
+
+	void run(Options const& options) const {
+		if (!available()) { throw std::runtime_error{std::format("{} not available", command)}; }
+
+		if (options.simulate && !options.quiet) { std::cout << "-- simulate enabled, source files will not be modified\n"; }
+
+		auto count{0};
+		if (!options.quiet) { std::cout << std::format("-- formatting source files in '{}' :\n\n", options.rootDir); }
+		for (auto const& itr : fs::recursive_directory_iterator{options.rootDir}) {
+			if (auto const& path = itr.path(); shouldFormat(path)) {
+				auto const pathString = path.generic_string();
+				if (!options.quiet) { std::cout << std::format("{}\n", pathString); }
+				if (!options.simulate) {
+					if (format(pathString)) { ++count; }
+				} else {
+					++count;
+				}
+			}
+		}
+		if (!options.quiet) { std::cout << "\n"; }
+		std::cout << std::format(" == {} source files formatted\n", count);
+	}
+};
+} // namespace
+
+int main(int argc, char** argv) {
+	assert(argc > 0);
+	auto const usage = Options::buildUsage(fs::path{*argv}.filename().string());
+	auto const args = std::span{argv, static_cast<std::size_t>(argc)}.subspan(1);
+	auto options = Options{};
+	try {
+		options.parse(args);
+
+		if (!fs::is_directory(options.rootDir)) {
+			std::cerr << std::format("failed to resolve root directory '{}'\n", options.rootDir);
+			return EXIT_FAILURE;
+		}
+
+		App{}.run(options);
+
+	} catch (Options::ParseError const& error) {
+		std::cerr << std::format("{}\n{}\n", error.what(), usage);
+		return EXIT_FAILURE;
+	} catch (Options::Usage) {
+		std::cout << std::format("{}\n", usage);
+		return EXIT_SUCCESS;
+	} catch (std::exception const& e) {
+		std::cerr << std::format("fatal error: {}\n", e.what());
+		return EXIT_FAILURE;
+	}
+}


### PR DESCRIPTION
The tool iterates over the root directory (working directory by default, or first positional argument if passed) and runs `clang-format -i <path>` on all `.hpp` and `.cpp` files (paths with `build/`, `out/`, `cmake/`, `ext/` are skipped).

State of repo after running the tool is demonstrated in [this draft PR](https://github.com/Rinzii/genesis/pull/26/files).

Tool accepts some basic command line options and prints usage on parse errors / if `--help` or `--usage` is passed.

It is currently single threaded.
