### PR TITLE
Ci clang patch

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -13,9 +13,9 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - name: install ninja and g++13
-        run: sudo apt update -yqq && sudo apt install -yqq ninja-build xorg-dev g++-13 && sudo apt --purge remove python3-lldb-14 
+        run: sudo apt update -yqq && sudo apt install -yqq ninja-build xorg-dev g++-13
       - name: update to clang 16
-        run: sudo wget https://apt.llvm.org/llvm.sh && sudo chmod +x llvm.sh && sudo ./llvm.sh 16
+        run: sudo apt --purge remove python3-lldb-14 && sudo wget https://apt.llvm.org/llvm.sh && sudo chmod +x llvm.sh && sudo ./llvm.sh 16
       - name: configure gcc
         run: cmake -S . --preset=default -B build -DCMAKE_CXX_COMPILER=g++-13
       - name: configure clang

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -13,7 +13,7 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - name: install ninja and g++13
-        run: sudo apt update -yqq && sudo apt install -yqq ninja-build xorg-dev g++-13
+        run: sudo apt update -yqq && sudo apt install -yqq ninja-build xorg-dev g++-13 && sudo apt --purge remove python3-lldb-14 
       - name: update to clang 16
         run: sudo wget https://apt.llvm.org/llvm.sh && sudo chmod +x llvm.sh && sudo ./llvm.sh 16
       - name: configure gcc


### PR DESCRIPTION
Something with the ci broke the clang update script. Not sure if it was GitHub actions or the script itself, but it created a dependency issue. This change just removes the dependency conflict. Pretty simple.