### PR TITLE
Add autoformat custom target.

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -5,7 +5,6 @@ AccessModifierOffset: -4
 AlignConsecutiveAssignments: Consecutive
 AlignConsecutiveMacros: Consecutive
 AlignEscapedNewlines: Right
-AlignTrailingComments: Always
 AllowShortEnumsOnASingleLine: true
 AllowShortCaseLabelsOnASingleLine: true
 AllowShortFunctionsOnASingleLine: InlineOnly
@@ -32,7 +31,6 @@ BraceWrapping:
     SplitEmptyFunction: true
     SplitEmptyRecord: true
     SplitEmptyNamespace: true
-BreakAfterAttributes: Never
 BreakBeforeBraces: Allman
 ColumnLimit: 160
 CompactNamespaces: false

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -47,7 +47,17 @@ if(GENESIS_BUILD_EDITOR)
   add_subdirectory(editor)
 endif()
 
-
 if (GENESIS_BUILD_TOOLS)
   add_subdirectory(tools/code-formatter)
+
+  add_custom_target(autoformat ALL
+    code-formatter -q engine
+    COMMAND code-formatter -q editor/src
+    WORKING_DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}"
+    USES_TERMINAL
+    COMMENT "Formatting sources"
+  )
+
+  add_dependencies(genesis autoformat)
+  add_dependencies(genesis-editor autoformat)
 endif()

--- a/editor/src/main.cpp
+++ b/editor/src/main.cpp
@@ -4,16 +4,20 @@
 #include <logger/instance.hpp>
 #include <logger/log.hpp>
 
-int main() {
+int main()
+{
 	auto logger = gen::logger::Instance{};
 
 	gen::Application app;
 
 	gen::logger::info("Hello, world!");
 
-	try {
+	try
+	{
 		app.run();
-	} catch (std::exception const& e) {
+	}
+	catch (std::exception const & e)
+	{
 		gen::logger::error(e.what());
 		return EXIT_FAILURE;
 	}

--- a/engine/include/application.hpp
+++ b/engine/include/application.hpp
@@ -4,22 +4,22 @@
 
 #include "windowing/window.hpp"
 
-namespace gen {
+namespace gen
+{
 
-class Application {
-public:
+	class Application
+	{
+	public:
+		void run();
 
-    void run();
+		// This is all kinda bad but it is gonna be replaced later
+		// Just using it for testing the rendering pipeline
+	public:
+		static constexpr u32 m_width  = 800;
+		static constexpr u32 m_height = 600;
 
-	// This is all kinda bad but it is gonna be replaced later
-	// Just using it for testing the rendering pipeline
-public:
-	static constexpr u32 m_width = 800;
-	static constexpr u32 m_height = 600;
-
-private:
-	Window m_window{ 800, 600, "Genesis Engine" };
-
-};
+	private:
+		Window m_window{800, 600, "Genesis Engine"};
+	};
 
 } // namespace gen

--- a/engine/include/base/base.hpp
+++ b/engine/include/base/base.hpp
@@ -10,7 +10,6 @@
 #include "base/config/architecture.hpp"
 #include "base/config/compiler.hpp"
 #include "base/config/compilerTraits.hpp"
-#include "base/config/platform.hpp"
 #include "base/config/defines.hpp"
+#include "base/config/platform.hpp"
 #include "base/config/settings.hpp"
-

--- a/engine/include/base/config/compiler.hpp
+++ b/engine/include/base/config/compiler.hpp
@@ -45,26 +45,26 @@
 
 // Clang's GCC-compatible driver.
 #if defined(__clang__) && !defined(_MSC_VER)
-	#define GEN_COMPILER_CLANG 1
+	#define GEN_COMPILER_CLANG	 1
 	#define GEN_COMPILER_VERSION (__clang_major__ * 100 + __clang_minor__)
-	#define GEN_COMPILER_NAME "clang"
-	#define GEN_COMPILER_STRING GEN_COMPILER_NAME __clang_version__
+	#define GEN_COMPILER_NAME	 "clang"
+	#define GEN_COMPILER_STRING	 GEN_COMPILER_NAME __clang_version__
 
 // GCC (a.k.a. GNUC)
 #elif defined(__GNUC__)
 	// Define interchangeably between GCC and GNUC. Though GEN_COMPILER_GCC is preferred.
-	#define GEN_COMPILER_GCC 1
-	#define GEN_COMPILER_GNUC 1
+	#define GEN_COMPILER_GCC	 1
+	#define GEN_COMPILER_GNUC	 1
 	#define GEN_COMPILER_VERSION (__GNUC__ * 1000 + __GNUC_MINOR__)
-	#define GEN_COMPILER_NAME "GCC"
-	#define GEN_COMPILER_STRING GEN_COMPILER_NAME " compiler, version " INTERNAL_STRINGIFY(__GNUC__) "." INTERNAL_STRINGIFY(__GNUC_MINOR__)
+	#define GEN_COMPILER_NAME	 "GCC"
+	#define GEN_COMPILER_STRING	 GEN_COMPILER_NAME " compiler, version " INTERNAL_STRINGIFY(__GNUC__) "." INTERNAL_STRINGIFY(__GNUC_MINOR__)
 
 #elif defined(_MSC_VER) // TODO: Validate everything is properly being set for MSVC
-	#define GEN_COMPILER_MSVC 1
+	#define GEN_COMPILER_MSVC	   1
 	#define GEN_COMPILER_MICROSOFT 1
-	#define GEN_COMPILER_VERSION _MSC_VER
-	#define GEN_COMPILER_NAME "Microsoft Visual C++"
-	#define GEN_COMPILER_STRING GEN_COMPILER_NAME " compiler, version " INTERNAL_STRINGIFY(_MSC_VER)
+	#define GEN_COMPILER_VERSION   _MSC_VER
+	#define GEN_COMPILER_NAME	   "Microsoft Visual C++"
+	#define GEN_COMPILER_STRING	   GEN_COMPILER_NAME " compiler, version " INTERNAL_STRINGIFY(_MSC_VER)
 
 	#if defined(__clang__)
 		// Clang's MSVC-compatible driver.

--- a/engine/include/core.hpp
+++ b/engine/include/core.hpp
@@ -8,6 +8,3 @@
 
 #include "base/base.hpp"
 #include "system/types.hpp"
-
-
-

--- a/engine/include/graphics/pipeline.hpp
+++ b/engine/include/graphics/pipeline.hpp
@@ -5,16 +5,18 @@
 #include <string>
 #include <vector>
 
-namespace gen {
+namespace gen
+{
 
-    class Pipeline {
-    public:
-        Pipeline(const std::string& vertFilePath, const std::string& fragFilePath);
+	class Pipeline
+	{
+	public:
+		Pipeline(const std::string & vertFilePath, const std::string & fragFilePath);
 
-    private:
-        static std::vector<char> readFile(const std::string& filePath);
+	private:
+		static std::vector<char> readFile(const std::string & filePath);
 
-        void createGraphicsPipeline(const std::string& vertFilePath, const std::string &fragFilePath);
-    };
+		void createGraphicsPipeline(const std::string & vertFilePath, const std::string & fragFilePath);
+	};
 
 } // namespace gen

--- a/engine/include/inputs/controller.hpp
+++ b/engine/include/inputs/controller.hpp
@@ -1,9 +1,9 @@
 // Copyright (c) 2023-present Genesis Engine contributors (see LICENSE.txt)
 
 #pragma once
-#include <vector>
 #include <GLFW/glfw3.h>
 #include <mim/vec2.hpp>
+#include <vector>
 #include "base/config/compilerTraits.hpp"
 
 namespace gen
@@ -18,30 +18,29 @@ namespace gen
 
 		void gamePadCallback(int id, int event);
 
-		Controller* getController(int i); //for testing purposes
-	}
+		Controller * getController(int i); // for testing purposes
+	}									   // namespace controllerManager
 
 	class Controller
 	{
 	public:
-
 		Controller(const int id);
 
 		void update();
 
 		constexpr void setActive(bool active) { m_active = active; } // TODO: change to a pointer to an entity
 
-		void setUserPointer(void* owner); // TODO: change to a pointer to an entity
+		void setUserPointer(void * owner); // TODO: change to a pointer to an entity
 
 		GEN_NODISCARD constexpr bool isActive() const { return m_active; }
-		GEN_NODISCARD constexpr void* getUserPointer() const { return m_userPointer; }
+		GEN_NODISCARD constexpr void * getUserPointer() const { return m_userPointer; }
 
-		GEN_NODISCARD constexpr mim::vec2<float> getLeftJoystick() const { return { m_axes[GLFW_GAMEPAD_AXIS_LEFT_X], m_axes[GLFW_GAMEPAD_AXIS_LEFT_Y] }; }
+		GEN_NODISCARD constexpr mim::vec2<float> getLeftJoystick() const { return {m_axes[GLFW_GAMEPAD_AXIS_LEFT_X], m_axes[GLFW_GAMEPAD_AXIS_LEFT_Y]}; }
 		GEN_NODISCARD constexpr float getLeftJoystickX() const { return m_axes[GLFW_GAMEPAD_AXIS_LEFT_X]; }
 		GEN_NODISCARD constexpr float getLeftJoystickY() const { return m_axes[GLFW_GAMEPAD_AXIS_LEFT_Y]; }
 		GEN_NODISCARD constexpr bool getLeftJoystickButton() const { return m_buttons[GLFW_GAMEPAD_BUTTON_LEFT_THUMB]; }
 
-		GEN_NODISCARD constexpr mim::vec2<float> getRightJoystick() const { return { m_axes[GLFW_GAMEPAD_AXIS_RIGHT_X], m_axes[GLFW_GAMEPAD_AXIS_RIGHT_Y] }; }
+		GEN_NODISCARD constexpr mim::vec2<float> getRightJoystick() const { return {m_axes[GLFW_GAMEPAD_AXIS_RIGHT_X], m_axes[GLFW_GAMEPAD_AXIS_RIGHT_Y]}; }
 		GEN_NODISCARD constexpr float getRightJoystickX() const { return m_axes[GLFW_GAMEPAD_AXIS_RIGHT_X]; }
 		GEN_NODISCARD constexpr float getRightJoystickY() const { return m_axes[GLFW_GAMEPAD_AXIS_RIGHT_Y]; }
 		GEN_NODISCARD constexpr bool getRightJoystickButton() const { return m_buttons[GLFW_GAMEPAD_BUTTON_RIGHT_THUMB]; }
@@ -68,20 +67,19 @@ namespace gen
 		GEN_NODISCARD constexpr int getID() const { return m_id; }
 
 	private:
+		void storeValue(const float * axes);
+		void storeValue(const unsigned char * buttons);
 
-		void storeValue(const float* axes);
-		void storeValue(const unsigned char* buttons);
+		int m_id{0};
 
-		int m_id { 0 };
+		int m_axesCount{0};
+		int m_buttonsCount{0};
 
-		int m_axesCount { 0 };
-		int m_buttonsCount { 0 };
-
-		void* m_userPointer = nullptr;
+		void * m_userPointer = nullptr;
 
 		std::vector<float> m_axes;
 		std::vector<unsigned char> m_buttons;
 
 		bool m_active = true;
 	};
-}
+} // namespace gen

--- a/engine/include/io/file.hpp
+++ b/engine/include/io/file.hpp
@@ -1,140 +1,136 @@
 /**
-* @file file.hpp
-* @brief Defines the Thread-safe Synchronous File class.
-*
-* This header provides the declaration of the Thread-safe Synchronous File class, which is designed
-* for safe file handling in a multi-threaded environment.
-*/
+ * @file file.hpp
+ * @brief Defines the Thread-safe Synchronous File class.
+ *
+ * This header provides the declaration of the Thread-safe Synchronous File class, which is designed
+ * for safe file handling in a multi-threaded environment.
+ */
 
 #pragma once
 
 #include "core.hpp"
 
 #include <filesystem>
-#include <string>
-#include <mutex>
 #include <fstream>
 #include <memory>
+#include <mutex>
+#include <string>
 
-namespace gen {
-
-namespace fs = std::filesystem;
-
-/**
-* @class File
-* @brief Thread-safe Synchronous File class.
-*
-* The File class provides a thread-safe mechanism for synchronous file handling.
-* It supports opening, reading, writing, seeking, and retrieving information about files.
-*/
-class File
+namespace gen
 {
-public:
-   /**
-    * @brief Enumeration of file modes.
-    */
-   enum Mode : int
-   {
-       in = std::ios::in,           //!< Read mode.
-       out = std::ios::out,         //!< Write mode.
-       ate = std::ios::ate,         //!< Open at the end of the file.
-       app = std::ios::app,         //!< Append mode.
-       trunc = std::ios::trunc,     //!< Truncate the file if it exists.
-       binary = std::ios::binary,   //!< Binary mode.
-   };
 
-   /**
-    * @brief Default constructor.
-    */
-   File() = default;
+	namespace fs = std::filesystem;
 
-   /**
-    * @brief Default destructor.
-    */
-   ~File() = default;
+	/**
+	 * @class File
+	 * @brief Thread-safe Synchronous File class.
+	 *
+	 * The File class provides a thread-safe mechanism for synchronous file handling.
+	 * It supports opening, reading, writing, seeking, and retrieving information about files.
+	 */
+	class File
+	{
+	public:
+		/**
+		 * @brief Enumeration of file modes.
+		 */
+		enum Mode : int
+		{
+			in	   = std::ios::in,	   //!< Read mode.
+			out	   = std::ios::out,	   //!< Write mode.
+			ate	   = std::ios::ate,	   //!< Open at the end of the file.
+			app	   = std::ios::app,	   //!< Append mode.
+			trunc  = std::ios::trunc,  //!< Truncate the file if it exists.
+			binary = std::ios::binary, //!< Binary mode.
+		};
 
-   // Disable copy and assignment
-   File(const File&) = delete;
-   File& operator=(const File&) = delete;
+		/**
+		 * @brief Default constructor.
+		 */
+		File() = default;
 
-   /**
-    * @brief Opens a file with the specified file path.
-    * @param filePath The path to the file.
-    * @return `true` if the file is successfully opened, `false` otherwise.
-    */
-   bool open(const fs::path& filePath);
+		/**
+		 * @brief Default destructor.
+		 */
+		~File() = default;
 
-   /**
-    * @brief Reads data from the file into the provided buffer.
-    * @param data Pointer to the buffer where the read data will be stored.
-    * @param dataSize The size of the data to read.
-    * @param bytesRead [out] The number of bytes actually read from the file.
-    * @return `true` if the read operation is successful, `false` otherwise.
-    */
-   bool read(void* data, std::size_t dataSize, u64& /* [out] */ bytesRead);
+		// Disable copy and assignment
+		File(const File &)			   = delete;
+		File & operator=(const File &) = delete;
 
-   /**
-    * @brief Reads data from the file into the provided buffer.
-    * @param data Pointer to the buffer where the read data will be stored.
-    * @param dataSize The size of the data to read.
-    * @param bytesRead [out] The number of bytes actually read from the file.
-    * @return `true` if the read operation is successful, `false` otherwise.
-    */
-   bool read(const void* data, std::size_t dataSize, u64& /* [out] */ bytesRead);
+		/**
+		 * @brief Opens a file with the specified file path.
+		 * @param filePath The path to the file.
+		 * @return `true` if the file is successfully opened, `false` otherwise.
+		 */
+		bool open(const fs::path & filePath);
 
-   /**
-    * @brief Writes data to the file.
-    * @param data Pointer to the data to be written.
-    * @param dataSize The size of the data to write.
-    * @param position The position in the file where the data will be written.
-    *        If set to -1, the data will be appended to the end of the file.
-    * @param mode The file mode for opening the file.
-    * @param flush Whether to flush the file after writing.
-    * @return `true` if the write operation is successful, `false` otherwise.
-    */
-   bool write(const void* data,
-              std::size_t dataSize,
-              std::streampos position = -1,
-              std::ios_base::openmode mode = std::ios::app,
-              bool flush = false);
+		/**
+		 * @brief Reads data from the file into the provided buffer.
+		 * @param data Pointer to the buffer where the read data will be stored.
+		 * @param dataSize The size of the data to read.
+		 * @param bytesRead [out] The number of bytes actually read from the file.
+		 * @return `true` if the read operation is successful, `false` otherwise.
+		 */
+		bool read(void * data, std::size_t dataSize, u64 & /* [out] */ bytesRead);
 
-   /**
-    * @brief Seeks to the specified position in the file.
-    * @param position The position to seek to.
-    * @return The new position in the file after seeking, or -1 if an error occurs.
-    */
-   i64 seek(i64 position);
+		/**
+		 * @brief Reads data from the file into the provided buffer.
+		 * @param data Pointer to the buffer where the read data will be stored.
+		 * @param dataSize The size of the data to read.
+		 * @param bytesRead [out] The number of bytes actually read from the file.
+		 * @return `true` if the read operation is successful, `false` otherwise.
+		 */
+		bool read(const void * data, std::size_t dataSize, u64 & /* [out] */ bytesRead);
 
-   /**
-    * @brief Returns the current position in the file.
-    * @return The current position in the file, or -1 if an error occurs.
-    */
-   i64 tell();
+		/**
+		 * @brief Writes data to the file.
+		 * @param data Pointer to the data to be written.
+		 * @param dataSize The size of the data to write.
+		 * @param position The position in the file where the data will be written.
+		 *        If set to -1, the data will be appended to the end of the file.
+		 * @param mode The file mode for opening the file.
+		 * @param flush Whether to flush the file after writing.
+		 * @return `true` if the write operation is successful, `false` otherwise.
+		 */
+		bool write(const void * data, std::size_t dataSize, std::streampos position = -1, std::ios_base::openmode mode = std::ios::app, bool flush = false);
 
-   /**
-    * @brief Checks if the file is valid and open.
-    * @return `true` if the file is valid and open, `false` otherwise.
-    */
-   GEN_NODISCARD bool isValid() const;
+		/**
+		 * @brief Seeks to the specified position in the file.
+		 * @param position The position to seek to.
+		 * @return The new position in the file after seeking, or -1 if an error occurs.
+		 */
+		i64 seek(i64 position);
 
-   /**
-    * @brief Returns the size of the file.
-    * @return The size of the file in bytes, or -1 if the file is not valid or an error occurs.
-    */
-   i64 getFileSize();
+		/**
+		 * @brief Returns the current position in the file.
+		 * @return The current position in the file, or -1 if an error occurs.
+		 */
+		i64 tell();
 
-   /**
-    * @brief Returns the timestamp of the file.
-    * @return The timestamp of the file as the number of seconds since the epoch,
-    *         or -1 if the file is not valid or an error occurs.
-    */
-   i64 getFileTimeStamp();
+		/**
+		 * @brief Checks if the file is valid and open.
+		 * @return `true` if the file is valid and open, `false` otherwise.
+		 */
+		GEN_NODISCARD bool isValid() const;
 
-private:
+		/**
+		 * @brief Returns the size of the file.
+		 * @return The size of the file in bytes, or -1 if the file is not valid or an error occurs.
+		 */
+		i64 getFileSize();
 
-   std::fstream m_file; //!< The file stream.
-   std::mutex m_mutex;  //!< Mutex for thread safety.
-   fs::path m_filePath; //!< The path to the file.
-};
+		/**
+		 * @brief Returns the timestamp of the file.
+		 * @return The timestamp of the file as the number of seconds since the epoch,
+		 *         or -1 if the file is not valid or an error occurs.
+		 */
+		i64 getFileTimeStamp();
+
+	private:
+		std::fstream m_file; //!< The file stream.
+		std::mutex m_mutex;	 //!< Mutex for thread safety.
+		fs::path m_filePath; //!< The path to the file.
+	};
 
 } // namespace gen

--- a/engine/include/io/fileAsync.hpp
+++ b/engine/include/io/fileAsync.hpp
@@ -4,9 +4,7 @@
 
 #include "core.hpp"
 
-
-namespace gen {
-
-
+namespace gen
+{
 
 } // namespace gen

--- a/engine/include/io/fileHelper.hpp
+++ b/engine/include/io/fileHelper.hpp
@@ -2,8 +2,11 @@
 
 #pragma once
 
-namespace gen {
+namespace gen
+{
 
-class fileHelper {};
+	class fileHelper
+	{
+	};
 
 } // namespace gen

--- a/engine/include/logger/context.hpp
+++ b/engine/include/logger/context.hpp
@@ -4,32 +4,36 @@
 #include <source_location>
 #include <string_view>
 
-namespace gen::logger {
-using Clock = std::chrono::system_clock;
-using SrcLoc = std::source_location;
-
-///
-/// \brief Strongly typed integer representing logging thread ID.
-///
-enum struct ThreadId : int {};
-
-///
-/// \brief Log context.
-///
-/// Expected to be built at the call site and passed around.
-///
-struct Context {
-	std::string_view category{};
-	Clock::time_point timestamp{};
-	std::source_location location{};
-	ThreadId thread{};
-	Level level{};
+namespace gen::logger
+{
+	using Clock	 = std::chrono::system_clock;
+	using SrcLoc = std::source_location;
 
 	///
-	/// \brief Obtain this thread's ID.
-	/// \returns Monotonically increasing IDs per thread, in order of being called for the first time.
+	/// \brief Strongly typed integer representing logging thread ID.
 	///
-	static ThreadId getThreadId();
-	static Context make(std::string_view category, Level level, SrcLoc const& location = SrcLoc::current());
-};
+	enum struct ThreadId : int
+	{
+	};
+
+	///
+	/// \brief Log context.
+	///
+	/// Expected to be built at the call site and passed around.
+	///
+	struct Context
+	{
+		std::string_view category{};
+		Clock::time_point timestamp{};
+		std::source_location location{};
+		ThreadId thread{};
+		Level level{};
+
+		///
+		/// \brief Obtain this thread's ID.
+		/// \returns Monotonically increasing IDs per thread, in order of being called for the first time.
+		///
+		static ThreadId getThreadId();
+		static Context make(std::string_view category, Level level, SrcLoc const & location = SrcLoc::current());
+	};
 } // namespace gen::logger

--- a/engine/include/logger/instance.hpp
+++ b/engine/include/logger/instance.hpp
@@ -5,60 +5,64 @@
 #include <memory>
 #include <stdexcept>
 
-namespace gen::logger {
-///
-/// \brief Logger Instance: a single instance must be created within main's scope.
-///
-class Instance {
-public:
+namespace gen::logger
+{
 	///
-	/// \brief Error thrown if more than one instance is attempted to be created.
+	/// \brief Logger Instance: a single instance must be created within main's scope.
 	///
-	struct DuplicateError : std::runtime_error {
-		using std::runtime_error::runtime_error;
+	class Instance
+	{
+	public:
+		///
+		/// \brief Error thrown if more than one instance is attempted to be created.
+		///
+		struct DuplicateError : std::runtime_error
+		{
+			using std::runtime_error::runtime_error;
+		};
+
+		Instance(Instance &&)			  = delete;
+		Instance & operator=(Instance &&) = delete;
+
+		Instance(Instance const &)			   = delete;
+		Instance & operator=(Instance const &) = delete;
+
+		///
+		/// \brief Create a logger Instance.
+		/// \param filePath path to create/overwrite log file at.
+		/// \param config Config to use.
+		///
+		explicit Instance(char const * filePath = "genesis.log", Config config = {});
+		~Instance();
+
+		///
+		/// \brief Obtain a copy of the Config in use.
+		///
+		[[nodiscard]] Config getConfig() const;
+		///
+		/// \brief Overwrite the Config in use.
+		///
+		void setConfig(Config config);
+
+		///
+		/// \brief Add a custom sink.
+		///
+		void addSink(std::unique_ptr<Sink> sink);
+
+		///
+		/// \brief Entrypoint for logging (free) functions.
+		///
+		static void print(std::string_view message, Context const & context);
+
+	private:
+		struct Impl;
+		struct Deleter
+		{
+			void operator()(Impl const * ptr) const;
+		};
+
+		// NOLINTNEXTLINE
+		inline static Impl * s_instance{};
+		std::unique_ptr<Impl, Deleter> m_impl{};
 	};
-
-	Instance(Instance&&) = delete;
-	Instance& operator=(Instance&&) = delete;
-
-	Instance(Instance const&) = delete;
-	Instance& operator=(Instance const&) = delete;
-
-	///
-	/// \brief Create a logger Instance.
-	/// \param filePath path to create/overwrite log file at.
-	/// \param config Config to use.
-	///
-	explicit Instance(char const* filePath = "genesis.log", Config config = {});
-	~Instance();
-
-	///
-	/// \brief Obtain a copy of the Config in use.
-	///
-	[[nodiscard]] Config getConfig() const;
-	///
-	/// \brief Overwrite the Config in use.
-	///
-	void setConfig(Config config);
-
-	///
-	/// \brief Add a custom sink.
-	///
-	void addSink(std::unique_ptr<Sink> sink);
-
-	///
-	/// \brief Entrypoint for logging (free) functions.
-	///
-	static void print(std::string_view message, Context const& context);
-
-private:
-	struct Impl;
-	struct Deleter {
-		void operator()(Impl const* ptr) const;
-	};
-
-	// NOLINTNEXTLINE
-	inline static Impl* s_instance{};
-	std::unique_ptr<Impl, Deleter> m_impl{};
-};
 } // namespace gen::logger

--- a/engine/include/logger/level.hpp
+++ b/engine/include/logger/level.hpp
@@ -1,22 +1,32 @@
 #pragma once
 #include <cstdint>
 
-namespace gen::logger {
-///
-/// \brief Log Level.
-///
-enum class Level : std::uint8_t { eError, eWarn, eInfo, eDebug, eCOUNT_ };
+namespace gen::logger
+{
+	///
+	/// \brief Log Level.
+	///
+	enum class Level : std::uint8_t
+	{
+		eError,
+		eWarn,
+		eInfo,
+		eDebug,
+		eCOUNT_
+	};
 
-///
-/// \brief char representation of Level.
-///
-constexpr char levelChar(Level const level) {
-	switch (level) {
-	case Level::eError: return 'E';
-	case Level::eWarn: return 'W';
-	case Level::eInfo: return 'I';
-	case Level::eDebug: return 'D';
-	default: return '?';
+	///
+	/// \brief char representation of Level.
+	///
+	constexpr char levelChar(Level const level)
+	{
+		switch (level)
+		{
+		case Level::eError: return 'E';
+		case Level::eWarn: return 'W';
+		case Level::eInfo: return 'I';
+		case Level::eDebug: return 'D';
+		default: return '?';
+		}
 	}
-}
 } // namespace gen::logger

--- a/engine/include/logger/log.hpp
+++ b/engine/include/logger/log.hpp
@@ -3,18 +3,37 @@
 #include <source_location>
 #include <string_view>
 
-namespace gen::logger {
-using SrcLoc = std::source_location;
+namespace gen::logger
+{
+	using SrcLoc = std::source_location;
 
-void error(std::string_view category, std::string_view message, SrcLoc const& location = SrcLoc::current());
-void warn(std::string_view category, std::string_view message, SrcLoc const& location = SrcLoc::current());
-void info(std::string_view category, std::string_view message, SrcLoc const& location = SrcLoc::current());
-void debug(std::string_view category, std::string_view message, SrcLoc const& location = SrcLoc::current());
-inline void log(std::string_view category, std::string_view message, SrcLoc const& location = SrcLoc::current()) { info(category, message, location); }
+	void error(std::string_view category, std::string_view message, SrcLoc const & location = SrcLoc::current());
+	void warn(std::string_view category, std::string_view message, SrcLoc const & location = SrcLoc::current());
+	void info(std::string_view category, std::string_view message, SrcLoc const & location = SrcLoc::current());
+	void debug(std::string_view category, std::string_view message, SrcLoc const & location = SrcLoc::current());
+	inline void log(std::string_view category, std::string_view message, SrcLoc const & location = SrcLoc::current())
+	{
+		info(category, message, location);
+	}
 
-inline void error(std::string_view message, SrcLoc const& location = SrcLoc::current()) { error("general", message, location); }
-inline void warn(std::string_view message, SrcLoc const& location = SrcLoc::current()) { warn("general", message, location); }
-inline void info(std::string_view message, SrcLoc const& location = SrcLoc::current()) { info("general", message, location); }
-inline void debug(std::string_view message, SrcLoc const& location = SrcLoc::current()) { debug("general", message, location); }
-inline void log(std::string_view message, SrcLoc const& location = SrcLoc::current()) { log("general", message, location); }
+	inline void error(std::string_view message, SrcLoc const & location = SrcLoc::current())
+	{
+		error("general", message, location);
+	}
+	inline void warn(std::string_view message, SrcLoc const & location = SrcLoc::current())
+	{
+		warn("general", message, location);
+	}
+	inline void info(std::string_view message, SrcLoc const & location = SrcLoc::current())
+	{
+		info("general", message, location);
+	}
+	inline void debug(std::string_view message, SrcLoc const & location = SrcLoc::current())
+	{
+		debug("general", message, location);
+	}
+	inline void log(std::string_view message, SrcLoc const & location = SrcLoc::current())
+	{
+		log("general", message, location);
+	}
 } // namespace gen::logger

--- a/engine/include/logger/sink.hpp
+++ b/engine/include/logger/sink.hpp
@@ -1,18 +1,20 @@
 #pragma once
 #include <logger/context.hpp>
 
-namespace gen::logger {
-///
-/// \brief Customizable log sink.
-///
-struct Sink {
-	virtual ~Sink() = default;
+namespace gen::logger
+{
+	///
+	/// \brief Customizable log sink.
+	///
+	struct Sink
+	{
+		virtual ~Sink() = default;
 
-	///
-	/// \brief Customization point for intercepting logs.
-	/// \param formatted Formatted log string.
-	/// \param context Log context.
-	///
-	virtual void handle(std::string_view formatted, Context const& context) = 0;
-};
+		///
+		/// \brief Customization point for intercepting logs.
+		/// \param formatted Formatted log string.
+		/// \param context Log context.
+		///
+		virtual void handle(std::string_view formatted, Context const & context) = 0;
+	};
 } // namespace gen::logger

--- a/engine/include/logger/target.hpp
+++ b/engine/include/logger/target.hpp
@@ -1,28 +1,30 @@
 #pragma once
 #include <cstdint>
 
-namespace gen::logger {
-///
-/// \brief Log Target (destination).
-///
-struct Target {
-	std::uint32_t value{};
+namespace gen::logger
+{
+	///
+	/// \brief Log Target (destination).
+	///
+	struct Target
+	{
+		std::uint32_t value{};
 
-	constexpr operator std::uint32_t() const { return value; }
-};
+		constexpr operator std::uint32_t() const { return value; }
+	};
 
-///
-/// \brief Standard IO streams.
-///
-inline constexpr Target console_v{.value = 1 << 0};
-///
-/// \brief Log file.
-///
-inline constexpr Target file_v{.value = 1 << 1};
-///
-/// \brief Custom sinks.
-///
-inline constexpr Target sinks_v{.value = 1 << 2};
+	///
+	/// \brief Standard IO streams.
+	///
+	inline constexpr Target console_v{.value = 1 << 0};
+	///
+	/// \brief Log file.
+	///
+	inline constexpr Target file_v{.value = 1 << 1};
+	///
+	/// \brief Custom sinks.
+	///
+	inline constexpr Target sinks_v{.value = 1 << 2};
 
-inline constexpr Target all_v{.value = 0xffffffff};
+	inline constexpr Target all_v{.value = 0xffffffff};
 } // namespace gen::logger

--- a/engine/include/system/types.hpp
+++ b/engine/include/system/types.hpp
@@ -6,13 +6,13 @@
 
 namespace gen
 {
-    using i8 = std::int8_t;
-    using i16 = std::int16_t;
-    using i32 = std::int32_t;
-    using i64 = std::int64_t;
+	using i8  = std::int8_t;
+	using i16 = std::int16_t;
+	using i32 = std::int32_t;
+	using i64 = std::int64_t;
 
-    using u8 = std::uint8_t;
-    using u16 = std::uint16_t;
-    using u32 = std::uint32_t;
-    using u64 = std::uint64_t;
-}
+	using u8  = std::uint8_t;
+	using u16 = std::uint16_t;
+	using u32 = std::uint32_t;
+	using u64 = std::uint64_t;
+} // namespace gen

--- a/engine/include/time.hpp
+++ b/engine/include/time.hpp
@@ -14,12 +14,12 @@ namespace gen
 		double GetTimeScale();
 
 		std::string GetCurrentTime();
-	}
+	} // namespace Time
 
 	namespace FPS
 	{
 		void SetFPSUpdateDelay(double updateDelay);
 		void UpdateFPS();
 		unsigned GetFPS();
-	}
-}
+	} // namespace FPS
+} // namespace gen

--- a/engine/include/util/fixed_string.hpp
+++ b/engine/include/util/fixed_string.hpp
@@ -3,29 +3,31 @@
 #include <array>
 #include <string_view>
 
-namespace gen {
-inline constexpr std::size_t fixed_string_capacity_v{64};
+namespace gen
+{
+	inline constexpr std::size_t fixed_string_capacity_v{64};
 
-///
-/// \brief Discount fixed capacity string.
-///
-template <std::size_t Capacity = fixed_string_capacity_v>
-class FixedString {
-public:
-	FixedString() = default;
+	///
+	/// \brief Discount fixed capacity string.
+	///
+	template <std::size_t Capacity = fixed_string_capacity_v>
+	class FixedString
+	{
+	public:
+		FixedString() = default;
 
-	constexpr FixedString(std::string_view const text) : m_size(std::min(Capacity, text.size())) { std::copy_n(text.begin(), m_size, m_buffer.data()); }
+		constexpr FixedString(std::string_view const text) : m_size(std::min(Capacity, text.size())) { std::copy_n(text.begin(), m_size, m_buffer.data()); }
 
-	[[nodiscard]] constexpr std::string_view view() const { return std::string_view{m_buffer.data(), m_size}; }
+		[[nodiscard]] constexpr std::string_view view() const { return std::string_view{m_buffer.data(), m_size}; }
 
-	constexpr operator std::string_view() const { return view(); }
+		constexpr operator std::string_view() const { return view(); }
 
-private:
-	std::array<char, Capacity> m_buffer{};
-	std::size_t m_size{};
-};
+	private:
+		std::array<char, Capacity> m_buffer{};
+		std::size_t m_size{};
+	};
 
-// unit tests
+	// unit tests
 
-static_assert(FixedString{"hello world"}.view() == "hello world");
+	static_assert(FixedString{"hello world"}.view() == "hello world");
 } // namespace gen

--- a/engine/include/util/version.hpp
+++ b/engine/include/util/version.hpp
@@ -4,15 +4,15 @@
 
 namespace gen
 {
-    ///
-    /// \brief Semantic Version
-    ///
-    struct Version
-    {
-        std::uint32_t major{};
-        std::uint32_t minor{};
-        std::uint32_t patch{};
+	///
+	/// \brief Semantic Version
+	///
+	struct Version
+	{
+		std::uint32_t major{};
+		std::uint32_t minor{};
+		std::uint32_t patch{};
 
-        auto operator <=> (Version const&) const = default;
-    };
+		auto operator<=>(Version const &) const = default;
+	};
 } // namespace gen

--- a/engine/include/windowing/window.hpp
+++ b/engine/include/windowing/window.hpp
@@ -11,43 +11,42 @@
 // Forward declare GLFWwindow
 struct GLFWwindow;
 
-namespace gen {
+namespace gen
+{
 
-class Window {
-public:
-    Window(int w, int h, std::string title);
-    ~Window();
+	class Window
+	{
+	public:
+		Window(int w, int h, std::string title);
+		~Window();
 
-	Window(const Window&) = delete;
-	Window& operator=(const Window&) = delete;
+		Window(const Window &)			   = delete;
+		Window & operator=(const Window &) = delete;
 
+	public:
+		GEN_NODISCARD bool shouldClose() const;
+		static void pollEvents();
 
-public:
-	GEN_NODISCARD bool shouldClose() const;
-	static void pollEvents() ;
+	public:
+		GEN_NODISCARD inline int GetWidth() const { return m_width; }
+		GEN_NODISCARD inline int GetHeight() const { return m_height; }
+		GEN_NODISCARD inline const std::string & GetTitle() const { return m_title; }
 
+		// TODO: Currently these functions will break the window.
 
-public:
-	GEN_NODISCARD inline int GetWidth() const { return m_width; }
-	GEN_NODISCARD inline int GetHeight() const { return m_height; }
-	GEN_NODISCARD inline const std::string& GetTitle() const { return m_title; }
+		void inline SetWidth(int width) { m_width = width; }
+		void inline SetHeight(int height) { m_height = height; }
+		void inline SetTitle(const std::string & title) { m_title = title; }
 
+	private:
+		void initWindow();
 
-	// TODO: Currently these functions will break the window.
+	private:
+		int m_width;
+		int m_height;
+		std::string m_title;
 
-	void inline SetWidth(int width) { m_width = width; }
-	void inline SetHeight(int height) { m_height = height; }
-	void inline SetTitle(const std::string& title) { m_title = title; }
-
-private:
-	void initWindow();
-
-private:
-	int m_width;
-	int m_height;
-	std::string m_title;
-
-	GLFWwindow* m_window;
-};
+		GLFWwindow * m_window;
+	};
 
 } // namespace gen

--- a/engine/src/application.cpp
+++ b/engine/src/application.cpp
@@ -4,13 +4,12 @@
 
 #include "application.hpp"
 
-namespace gen {
+namespace gen
+{
 
-	void Application::run() {
-		while (!m_window.shouldClose()) {
-			gen::Window::pollEvents();
-		}
+	void Application::run()
+	{
+		while (!m_window.shouldClose()) { gen::Window::pollEvents(); }
 	}
 
 } // namespace gen
-

--- a/engine/src/graphics/pipeline.cpp
+++ b/engine/src/graphics/pipeline.cpp
@@ -5,25 +5,26 @@
 #include <fstream>
 #include <stdexcept>
 
-namespace gen {
-    Pipeline::Pipeline(const std::string& vertFilePath, const std::string& fragFilePath) {
-        createGraphicsPipeline(vertFilePath, fragFilePath);
-    }
+namespace gen
+{
+	Pipeline::Pipeline(const std::string & vertFilePath, const std::string & fragFilePath)
+	{
+		createGraphicsPipeline(vertFilePath, fragFilePath);
+	}
 
-    std::vector<char> Pipeline::readFile(const std::string & filePath) {
-        std::ifstream file(filePath, std::ios::ate | std::ios::binary);
+	std::vector<char> Pipeline::readFile(const std::string & filePath)
+	{
+		std::ifstream file(filePath, std::ios::ate | std::ios::binary);
 
-	    if (!file.is_open()) {
-            throw std::runtime_error("failed to open file: " + filePath);
-        }
+		if (!file.is_open()) { throw std::runtime_error("failed to open file: " + filePath); }
 
-	    std::size_t fileSize = static_cast<size_t>(file.tellg());
+		std::size_t fileSize = static_cast<size_t>(file.tellg());
 
 		return std::vector<char>();
-    }
+	}
 
-	void Pipeline::createGraphicsPipeline(const std::string& vertFilePath, const std::string &fragFilePath) {
-
-    }
+	void Pipeline::createGraphicsPipeline(const std::string & vertFilePath, const std::string & fragFilePath)
+	{
+	}
 
 } // namespace gen

--- a/engine/src/inputs/controller.cpp
+++ b/engine/src/inputs/controller.cpp
@@ -8,7 +8,7 @@ namespace gen
 	{
 		namespace
 		{
-			std::vector<Controller> g_connectedControllers; //Max 16 (because of GLFW)
+			std::vector<Controller> g_connectedControllers; // Max 16 (because of GLFW)
 		}
 
 		void init()
@@ -19,17 +19,11 @@ namespace gen
 
 			while (glfwJoystickPresent(alreadyConnectedGamePadCount) != 0)
 			{
-				if (glfwJoystickIsGamepad(alreadyConnectedGamePadCount))
-				{
-					g_connectedControllers.emplace_back(alreadyConnectedGamePadCount);
-				}
-					
+				if (glfwJoystickIsGamepad(alreadyConnectedGamePadCount)) { g_connectedControllers.emplace_back(alreadyConnectedGamePadCount); }
+
 				alreadyConnectedGamePadCount++;
 
-				if (alreadyConnectedGamePadCount == GLFW_JOYSTICK_LAST)
-				{
-					break;
-				}
+				if (alreadyConnectedGamePadCount == GLFW_JOYSTICK_LAST) { break; }
 			}
 		}
 
@@ -37,10 +31,7 @@ namespace gen
 		{
 			for (auto & connectedController : g_connectedControllers)
 			{
-				if (connectedController.isActive())
-				{
-					connectedController.update();
-				}
+				if (connectedController.isActive()) { connectedController.update(); }
 			}
 		}
 
@@ -67,36 +58,28 @@ namespace gen
 			case GLFW_DISCONNECTED:
 				for (auto & connectedController : g_connectedControllers)
 				{
-					if (connectedController.getID() == id)
-					{
-						connectedController.setActive(false);
-					}
+					if (connectedController.getID() == id) { connectedController.setActive(false); }
 				}
 				break;
 
-			default: 
-				return;
+			default: return;
 			}
 		}
 
-		Controller* getController(int i)
+		Controller * getController(int i)
 		{
-			if (i < g_connectedControllers.size() && g_connectedControllers[i].isActive())
-			{
-				return &g_connectedControllers[i];
-			}
+			if (i < g_connectedControllers.size() && g_connectedControllers[i].isActive()) { return &g_connectedControllers[i]; }
 
 			return nullptr;
 		}
-	}
+	} // namespace controllerManager
 
-	Controller::Controller(const int id)
-		: m_id(id)
+	Controller::Controller(const int id) : m_id(id)
 	{
 		glfwGetJoystickAxes(m_id, &m_axesCount);
 		glfwGetJoystickButtons(m_id, &m_buttonsCount);
 
-		m_axes = std::vector<float>(m_axesCount, 0);
+		m_axes	  = std::vector<float>(m_axesCount, 0);
 		m_buttons = std::vector<unsigned char>(m_buttonsCount, '0');
 	}
 
@@ -116,19 +99,13 @@ namespace gen
 	{
 		m_axes.clear();
 
-		for (int i = 0; i < m_axesCount; i++)
-		{
-			m_axes.push_back((axes[i] + 1) / 2);
-		}
+		for (int i = 0; i < m_axesCount; i++) { m_axes.push_back((axes[i] + 1) / 2); }
 	}
 
 	void Controller::storeValue(const unsigned char * buttons)
 	{
 		m_buttons.clear();
 
-		for (int i = 0; i < m_buttonsCount; i++)
-		{
-			m_buttons.push_back(buttons[i]);
-		}
+		for (int i = 0; i < m_buttonsCount; i++) { m_buttons.push_back(buttons[i]); }
 	}
-}
+} // namespace gen

--- a/engine/src/io/file.cpp
+++ b/engine/src/io/file.cpp
@@ -1,37 +1,33 @@
 // Copyright (c) 2023-present Genesis Engine contributors (see LICENSE.txt)
 
 #include "io/file.hpp"
-#include <stdexcept>
 #include <chrono>
+#include <stdexcept>
 
+namespace gen
+{
 
-namespace gen {
-
-
-    bool File::open(const fs::path & filePath)
+	bool File::open(const fs::path & filePath)
 	{
 		std::lock_guard<std::mutex> lock(m_mutex); // Lock the mutex to ensure thread safety
 
 		m_filePath = filePath;
 
-	    std::ofstream createFile(filePath);
-	    if (!createFile.is_open())
-        {
-            return false;
-        }
+		std::ofstream createFile(filePath);
+		if (!createFile.is_open()) { return false; }
 
-	    m_file.open(filePath, std::ios::in | std::ios::out | std::ios::binary);
+		m_file.open(filePath, std::ios::in | std::ios::out | std::ios::binary);
 
-	    return m_file.is_open();
-    }
+		return m_file.is_open();
+	}
 
-	bool File::read(void* data, const std::size_t dataSize, u64& /* [out] */ bytesRead)
+	bool File::read(void * data, const std::size_t dataSize, u64 & /* [out] */ bytesRead)
 	{
 		std::lock_guard<std::mutex> lock(m_mutex);
 
 		if (m_file.is_open() && data != nullptr && dataSize > 0)
 		{
-			m_file.read(static_cast<char*>(data), static_cast<std::streamsize>(dataSize));
+			m_file.read(static_cast<char *>(data), static_cast<std::streamsize>(dataSize));
 			const std::streamsize readSize = m_file.gcount();
 			if (readSize > 0)
 			{
@@ -43,13 +39,13 @@ namespace gen {
 		return false;
 	}
 
-	bool File::read(const void* data, const std::size_t dataSize, u64& bytesRead)
+	bool File::read(const void * data, const std::size_t dataSize, u64 & bytesRead)
 	{
 		std::lock_guard<std::mutex> lock(m_mutex);
 
 		if (m_file.is_open() && data != nullptr && dataSize > 0)
 		{
-			m_file.read(reinterpret_cast<char*>(const_cast<void*>(data)), static_cast<std::streamsize>(dataSize));
+			m_file.read(reinterpret_cast<char *>(const_cast<void *>(data)), static_cast<std::streamsize>(dataSize));
 			const std::streamsize readSize = m_file.gcount();
 			if (readSize > 0)
 			{
@@ -61,12 +57,7 @@ namespace gen {
 		return false;
 	}
 
-
-	bool File::write(const void * data,
-					 const std::size_t dataSize,
-					 const std::streampos position,
-					 const std::ios_base::openmode mode,
-					 const bool flush)
+	bool File::write(const void * data, const std::size_t dataSize, const std::streampos position, const std::ios_base::openmode mode, const bool flush)
 	{
 		std::lock_guard<std::mutex> lock(m_mutex); // Lock the mutex to ensure thread safety
 
@@ -79,20 +70,18 @@ namespace gen {
 			}
 
 			// Write the data to the file
-			m_file.write(static_cast<const char*>(data), static_cast<std::streamsize>(dataSize));
+			m_file.write(static_cast<const char *>(data), static_cast<std::streamsize>(dataSize));
 
-			if (flush)
-			{
-				m_file.flush();
-			}
+			if (flush) { m_file.flush(); }
 
 			return true;
 		}
 
 		return false;
-		}
+	}
 
-	i64 File::seek(const i64 position) {
+	i64 File::seek(const i64 position)
+	{
 		std::lock_guard<std::mutex> lock(m_mutex);
 
 		if (m_file.is_open())
@@ -100,33 +89,23 @@ namespace gen {
 			m_file.seekg(position, std::ios::beg);
 			m_file.seekp(position, std::ios::beg);
 
-			if (m_file.fail())
-			{
-				return -1;
-			}
+			if (m_file.fail()) { return -1; }
 
 			return tell();
 		}
-		else
-		{
-			return -1;
-		}
+		else { return -1; }
 	}
 
-	i64 File::tell() {
+	i64 File::tell()
+	{
 		std::lock_guard<std::mutex> lock(m_mutex); // Lock the mutex to ensure thread safety
 
-		if (m_file.is_open())
-		{
-			return static_cast<i64>(m_file.tellg());
-		}
-		else
-		{
-			return -1;
-		}
+		if (m_file.is_open()) { return static_cast<i64>(m_file.tellg()); }
+		else { return -1; }
 	}
 
-	bool File::isValid() const {
+	bool File::isValid() const
+	{
 		return m_file.is_open();
 	}
 
@@ -134,20 +113,16 @@ namespace gen {
 	{
 		std::lock_guard<std::mutex> lock(m_mutex); // Lock the mutex to ensure thread safety
 
-        if (m_file.is_open())
-        {
-            m_file.seekg(0, std::ios::end);
+		if (m_file.is_open())
+		{
+			m_file.seekg(0, std::ios::end);
 			const std::streampos fileSize = m_file.tellg();
 
-            if (fileSize != -1)
-            {
-                return static_cast<i64>(fileSize);
-            }
-        }
+			if (fileSize != -1) { return static_cast<i64>(fileSize); }
+		}
 
-        return -1; // Return -1 if the file is not valid or if there was an error getting the file size
+		return -1; // Return -1 if the file is not valid or if there was an error getting the file size
 	}
-
 
 	i64 File::getFileTimeStamp()
 	{
@@ -155,16 +130,12 @@ namespace gen {
 
 		if (m_file.is_open())
 		{
-            const std::filesystem::path filePath = m_filePath;
+			const std::filesystem::path filePath				= m_filePath;
 			const std::filesystem::file_time_type lastWriteTime = std::filesystem::last_write_time(filePath);
-            return std::chrono::duration_cast<std::chrono::seconds>(lastWriteTime.time_since_epoch()).count();
-
+			return std::chrono::duration_cast<std::chrono::seconds>(lastWriteTime.time_since_epoch()).count();
 		}
 
 		return -1; // Return -1 if the file is not valid or if there was an error getting the file timestamp
 	}
 
-
-
-
-	} // namespace gen
+} // namespace gen

--- a/engine/src/io/fileAsync.cpp
+++ b/engine/src/io/fileAsync.cpp
@@ -2,6 +2,7 @@
 
 #include "io/fileAsync.hpp"
 
-namespace gen {
+namespace gen
+{
 
 } // namespace gen

--- a/engine/src/io/fileHelper.cpp
+++ b/engine/src/io/fileHelper.cpp
@@ -2,4 +2,6 @@
 
 #include "io/fileHelper.hpp"
 
-namespace gen {} // namespace gen
+namespace gen
+{
+} // namespace gen

--- a/engine/src/logger/context.cpp
+++ b/engine/src/logger/context.cpp
@@ -1,23 +1,27 @@
 #include "logger/context.hpp"
 #include <atomic>
 
-namespace gen::logger {
-ThreadId Context::getThreadId() {
-	auto const get_next_id = [] {
-		static auto s_prevId{std::atomic<int>{}};
-		return s_prevId++;
-	};
-	thread_local auto const s_thisThreadId{get_next_id()};
-	return ThreadId{s_thisThreadId};
-}
+namespace gen::logger
+{
+	ThreadId Context::getThreadId()
+	{
+		auto const get_next_id = []
+		{
+			static auto s_prevId{std::atomic<int>{}};
+			return s_prevId++;
+		};
+		thread_local auto const s_thisThreadId{get_next_id()};
+		return ThreadId{s_thisThreadId};
+	}
 
-Context Context::make(std::string_view category, Level level, SrcLoc const& location) {
-	return Context{
-		.category = category,
-		.timestamp = Clock::now(),
-		.location = location,
-		.thread = getThreadId(),
-		.level = level,
-	};
-}
+	Context Context::make(std::string_view category, Level level, SrcLoc const & location)
+	{
+		return Context{
+			.category  = category,
+			.timestamp = Clock::now(),
+			.location  = location,
+			.thread	   = getThreadId(),
+			.level	   = level,
+		};
+	}
 } // namespace gen::logger

--- a/engine/src/logger/log.cpp
+++ b/engine/src/logger/log.cpp
@@ -1,20 +1,25 @@
 #include "logger/log.hpp"
 #include "logger/instance.hpp"
 
-namespace gen {
-void logger::error(std::string_view category, std::string_view message, SrcLoc const& location) {
-	Instance::print(message, Context::make(category, Level::eError, location));
-}
+namespace gen
+{
+	void logger::error(std::string_view category, std::string_view message, SrcLoc const & location)
+	{
+		Instance::print(message, Context::make(category, Level::eError, location));
+	}
 
-void logger::warn(std::string_view category, std::string_view message, SrcLoc const& location) {
-	Instance::print(message, Context::make(category, Level::eWarn, location));
-}
+	void logger::warn(std::string_view category, std::string_view message, SrcLoc const & location)
+	{
+		Instance::print(message, Context::make(category, Level::eWarn, location));
+	}
 
-void logger::info(std::string_view category, std::string_view message, SrcLoc const& location) {
-	Instance::print(message, Context::make(category, Level::eInfo, location));
-}
+	void logger::info(std::string_view category, std::string_view message, SrcLoc const & location)
+	{
+		Instance::print(message, Context::make(category, Level::eInfo, location));
+	}
 
-void logger::debug(std::string_view category, std::string_view message, SrcLoc const& location) {
-	Instance::print(message, Context::make(category, Level::eDebug, location));
-}
+	void logger::debug(std::string_view category, std::string_view message, SrcLoc const & location)
+	{
+		Instance::print(message, Context::make(category, Level::eDebug, location));
+	}
 } // namespace gen

--- a/engine/src/time.cpp
+++ b/engine/src/time.cpp
@@ -9,25 +9,35 @@ namespace gen
 			Clock::time_point g_start{Clock::now()};
 			double g_deltaTime;
 			double g_timeScale;
-		}
+		} // namespace
 
-		void UpdateDeltaTime() {
+		void UpdateDeltaTime()
+		{
 			auto const end = Clock::now();
-			g_deltaTime = std::chrono::duration_cast<std::chrono::duration<double>>(end - g_start).count() * g_timeScale;
-			g_start = end;
+			g_deltaTime	   = std::chrono::duration_cast<std::chrono::duration<double>>(end - g_start).count() * g_timeScale;
+			g_start		   = end;
 		}
 
-		void SetTimeScale(double timeScale) { g_timeScale = timeScale; }
-		double GetDeltaTime() { return g_deltaTime; }
-		double GetTimeScale() { return g_timeScale; }
+		void SetTimeScale(double timeScale)
+		{
+			g_timeScale = timeScale;
+		}
+		double GetDeltaTime()
+		{
+			return g_deltaTime;
+		}
+		double GetTimeScale()
+		{
+			return g_timeScale;
+		}
 
-		std::string GetCurrentTime() {
-			auto const time = std::chrono::current_zone()
-				->to_local(std::chrono::system_clock::now());
+		std::string GetCurrentTime()
+		{
+			auto const time = std::chrono::current_zone()->to_local(std::chrono::system_clock::now());
 
 			return std::format("{:%Y-%m-%d %X}", time);
 		}
-	}
+	} // namespace Time
 
 	namespace FPS
 	{
@@ -36,22 +46,28 @@ namespace gen
 			double g_updateDelay = 0.5;
 			double g_updateTimer;
 			unsigned g_fps;
+		} // namespace
+
+		void SetFPSUpdateDelay(double updateDelay)
+		{
+			g_updateDelay = updateDelay;
 		}
 
-		void SetFPSUpdateDelay(double updateDelay) { g_updateDelay = updateDelay; }
-
-		void UpdateFPS() {
+		void UpdateFPS()
+		{
 
 			g_updateTimer += Time::GetDeltaTime();
 
-			if (g_updateTimer >= g_updateDelay) {
+			if (g_updateTimer >= g_updateDelay)
+			{
 				g_updateTimer = 0;
-				g_fps = 1 / (Time::GetDeltaTime() / Time::GetTimeScale());
+				g_fps		  = 1 / (Time::GetDeltaTime() / Time::GetTimeScale());
 			}
 		}
 
-		unsigned GetFPS() {
+		unsigned GetFPS()
+		{
 			return g_fps;
 		}
-	}
-}
+	} // namespace FPS
+} // namespace gen

--- a/engine/src/windowing/window.cpp
+++ b/engine/src/windowing/window.cpp
@@ -6,33 +6,36 @@
 
 #include <utility>
 
-namespace gen {
+namespace gen
+{
 
-    Window::Window(int w, int h, std::string title) : m_width{w}, m_height{h}, m_title{std::move(title)} { // NOLINT(cppcoreguidelines-pro-type-member-init)
-        initWindow();
-    }
+	Window::Window(int w, int h, std::string title) : m_width{w}, m_height{h}, m_title{std::move(title)}
+	{ // NOLINT(cppcoreguidelines-pro-type-member-init)
+		initWindow();
+	}
 
-	Window::~Window() {
-        glfwDestroyWindow(m_window);
-    }
+	Window::~Window()
+	{
+		glfwDestroyWindow(m_window);
+	}
 
-	bool Window::shouldClose() const {
-        return glfwWindowShouldClose(m_window);
-    }
+	bool Window::shouldClose() const
+	{
+		return glfwWindowShouldClose(m_window);
+	}
 
-	void Window::pollEvents() {
-        glfwPollEvents();
-    }
+	void Window::pollEvents()
+	{
+		glfwPollEvents();
+	}
 
-	void Window::initWindow() {
-        glfwInit();
-        glfwWindowHint(GLFW_CLIENT_API, GLFW_NO_API);
-        glfwWindowHint(GLFW_RESIZABLE, GLFW_FALSE); // TODO: Later add support for resizing of windows.
+	void Window::initWindow()
+	{
+		glfwInit();
+		glfwWindowHint(GLFW_CLIENT_API, GLFW_NO_API);
+		glfwWindowHint(GLFW_RESIZABLE, GLFW_FALSE); // TODO: Later add support for resizing of windows.
 
-        m_window = glfwCreateWindow(m_width, m_height, m_title.c_str(), nullptr, nullptr);
+		m_window = glfwCreateWindow(m_width, m_height, m_title.c_str(), nullptr, nullptr);
+	}
 
-    }
-
-
-
-} // namespace gwn
+} // namespace gen


### PR DESCRIPTION
Format all sources in engine/ and editor/src/ before building either targets. Remove some format specifications that are throwing errors (probably too new).