### PR TITLE
Add varaidic logging, Logger class.

### DIFF
--- a/editor/src/main.cpp
+++ b/editor/src/main.cpp
@@ -10,7 +10,7 @@ int main()
 
 	gen::Application app;
 
-	gen::logger::info("Hello, world!");
+	gen::logger::general.info("Hello, world!");
 
 	try
 	{
@@ -18,7 +18,7 @@ int main()
 	}
 	catch (std::exception const & e)
 	{
-		gen::logger::error(e.what());
+		gen::logger::general.error("{}", e.what());
 		return EXIT_FAILURE;
 	}
 

--- a/engine/include/application.hpp
+++ b/engine/include/application.hpp
@@ -2,6 +2,7 @@
 
 #pragma once
 
+#include <logger/log.hpp>
 #include "windowing/window.hpp"
 
 namespace gen
@@ -14,12 +15,13 @@ namespace gen
 
 		// This is all kinda bad but it is gonna be replaced later
 		// Just using it for testing the rendering pipeline
-	public:
 		static constexpr u32 m_width  = 800;
 		static constexpr u32 m_height = 600;
 
 	private:
 		Window m_window{800, 600, "Genesis Engine"};
+
+		Logger m_logger{"Application"};
 	};
 
 } // namespace gen

--- a/engine/include/logger/config.hpp
+++ b/engine/include/logger/config.hpp
@@ -17,15 +17,6 @@ namespace gen::logger
 		eUtc
 	};
 
-	///
-	/// \brief Source location mode.
-	///
-	enum class Location
-	{
-		eFilename,
-		eFullPath
-	};
-
 	struct Config
 	{
 		///
@@ -40,9 +31,8 @@ namespace gen::logger
 		///  category: log category
 		///  message: log message
 		///  timestamp: log timestamp
-		///  location: log source location
 		///
-		static constexpr std::string_view default_format_v{"[{level}][T{thread}] [{category}] {message} [{timestamp}] [{location}]"};
+		static constexpr std::string_view default_format_v{"[{level}][T{thread}] [{category}] {message} [{timestamp}]"};
 
 		static constexpr std::size_t format_size_v{128};
 
@@ -68,9 +58,5 @@ namespace gen::logger
 		/// \brief Timestamp mode.
 		///
 		Timestamp timestamp{Timestamp::eLocal};
-		///
-		/// \brief Source location mode.
-		///
-		Location location{Location::eFilename};
 	};
 } // namespace gen::logger

--- a/engine/include/logger/context.hpp
+++ b/engine/include/logger/context.hpp
@@ -1,13 +1,11 @@
 #pragma once
 #include <logger/level.hpp>
 #include <chrono>
-#include <source_location>
 #include <string_view>
 
 namespace gen::logger
 {
-	using Clock	 = std::chrono::system_clock;
-	using SrcLoc = std::source_location;
+	using Clock = std::chrono::system_clock;
 
 	///
 	/// \brief Strongly typed integer representing logging thread ID.
@@ -25,7 +23,6 @@ namespace gen::logger
 	{
 		std::string_view category{};
 		Clock::time_point timestamp{};
-		std::source_location location{};
 		ThreadId thread{};
 		Level level{};
 
@@ -34,6 +31,6 @@ namespace gen::logger
 		/// \returns Monotonically increasing IDs per thread, in order of being called for the first time.
 		///
 		static ThreadId getThreadId();
-		static Context make(std::string_view category, Level level, SrcLoc const & location = SrcLoc::current());
+		static Context make(std::string_view category, Level level);
 	};
 } // namespace gen::logger

--- a/engine/include/logger/log.hpp
+++ b/engine/include/logger/log.hpp
@@ -1,39 +1,59 @@
 #pragma once
+#include <logger/level.hpp>
 #include <logger/target.hpp>
-#include <source_location>
+#include <format>
 #include <string_view>
 
-namespace gen::logger
+namespace gen
 {
-	using SrcLoc = std::source_location;
+	namespace logger
+	{
+		void print(Level level, std::string_view category, std::string_view message);
+	} // namespace logger
 
-	void error(std::string_view category, std::string_view message, SrcLoc const & location = SrcLoc::current());
-	void warn(std::string_view category, std::string_view message, SrcLoc const & location = SrcLoc::current());
-	void info(std::string_view category, std::string_view message, SrcLoc const & location = SrcLoc::current());
-	void debug(std::string_view category, std::string_view message, SrcLoc const & location = SrcLoc::current());
-	inline void log(std::string_view category, std::string_view message, SrcLoc const & location = SrcLoc::current())
+	class Logger
 	{
-		info(category, message, location);
-	}
+	public:
+		using Level = logger::Level;
 
-	inline void error(std::string_view message, SrcLoc const & location = SrcLoc::current())
+		explicit Logger(std::string_view category);
+
+		template <typename... Args>
+		void error(std::format_string<Args...> fmt, Args &&... args) const
+		{
+			logger::print(Level::eError, m_category, std::format(fmt, std::forward<Args>(args)...));
+		}
+
+		template <typename... Args>
+		void warn(std::format_string<Args...> fmt, Args &&... args) const
+		{
+			logger::print(Level::eWarn, m_category, std::format(fmt, std::forward<Args>(args)...));
+		}
+
+		template <typename... Args>
+		void info(std::format_string<Args...> fmt, Args &&... args) const
+		{
+			logger::print(Level::eInfo, m_category, std::format(fmt, std::forward<Args>(args)...));
+		}
+
+		template <typename... Args>
+		void log(std::format_string<Args...> fmt, Args &&... args) const
+		{
+			info(fmt, std::forward<Args>(args)...);
+		}
+
+		template <typename... Args>
+		void debug(std::format_string<Args...> fmt, Args &&... args) const
+		{
+			logger::print(Level::eDebug, m_category, std::format(fmt, std::forward<Args>(args)...));
+		}
+
+	private:
+		std::string_view m_category{};
+	};
+
+	namespace logger
 	{
-		error("general", message, location);
+		inline Logger const general{"general"};
 	}
-	inline void warn(std::string_view message, SrcLoc const & location = SrcLoc::current())
-	{
-		warn("general", message, location);
-	}
-	inline void info(std::string_view message, SrcLoc const & location = SrcLoc::current())
-	{
-		info("general", message, location);
-	}
-	inline void debug(std::string_view message, SrcLoc const & location = SrcLoc::current())
-	{
-		debug("general", message, location);
-	}
-	inline void log(std::string_view message, SrcLoc const & location = SrcLoc::current())
-	{
-		log("general", message, location);
-	}
-} // namespace gen::logger
+} // namespace gen

--- a/engine/src/application.cpp
+++ b/engine/src/application.cpp
@@ -3,12 +3,15 @@
 // TODO: Replace this with a proper implementation
 
 #include "application.hpp"
+#include <numbers>
 
 namespace gen
 {
 
 	void Application::run()
 	{
+		m_logger.debug("Testing logger: {:.2f} {}", std::numbers::pi_v<float>, "hello world");
+
 		while (!m_window.shouldClose()) { gen::Window::pollEvents(); }
 	}
 

--- a/engine/src/logger/context.cpp
+++ b/engine/src/logger/context.cpp
@@ -14,12 +14,11 @@ namespace gen::logger
 		return ThreadId{s_thisThreadId};
 	}
 
-	Context Context::make(std::string_view category, Level level, SrcLoc const & location)
+	Context Context::make(std::string_view category, Level level)
 	{
 		return Context{
 			.category  = category,
 			.timestamp = Clock::now(),
-			.location  = location,
 			.thread	   = getThreadId(),
 			.level	   = level,
 		};

--- a/engine/src/logger/instance.cpp
+++ b/engine/src/logger/instance.cpp
@@ -36,17 +36,6 @@ namespace gen::logger
 			out.append(buffer.data());
 		}
 
-		void append_location(std::string & out, std::source_location const & location, Location const mode)
-		{
-			auto const path = [&]
-			{
-				auto ret = fs::path{location.file_name()};
-				if (mode == Location::eFilename) { ret = ret.filename(); }
-				return ret.generic_string();
-			}();
-			out.append(path);
-		}
-
 		struct Formatter
 		{
 			static constexpr auto open_v{'{'};
@@ -60,7 +49,6 @@ namespace gen::logger
 				// default format string size is 57, which will cause std::string to heap allocate.
 				// thus we use a fixed capacity stack string instead.
 				FixedString<Config::format_size_v> format{};
-				Location location{};
 				Timestamp timestamp{};
 			};
 
@@ -136,12 +124,6 @@ namespace gen::logger
 				if (key == "timestamp")
 				{
 					append_timestamp(out, context.timestamp, data.timestamp);
-					return true;
-				}
-
-				if (key == "location")
-				{
-					append_location(out, context.location, data.location);
 					return true;
 				}
 
@@ -257,7 +239,7 @@ namespace gen::logger
 				return all_v;
 			}();
 
-			auto const data = Formatter::Data{.format = config.format, .location = config.location, .timestamp = config.timestamp};
+			auto const data = Formatter::Data{.format = config.format, .timestamp = config.timestamp};
 			// cache this for later use
 			auto const sinks_empty = sinks.empty();
 			// config access complete, release lock

--- a/engine/src/logger/log.cpp
+++ b/engine/src/logger/log.cpp
@@ -3,23 +3,12 @@
 
 namespace gen
 {
-	void logger::error(std::string_view category, std::string_view message, SrcLoc const & location)
+	void logger::print(logger::Level level, std::string_view category, std::string_view message)
 	{
-		Instance::print(message, Context::make(category, Level::eError, location));
+		Instance::print(message, Context::make(category, level));
 	}
 
-	void logger::warn(std::string_view category, std::string_view message, SrcLoc const & location)
+	Logger::Logger(std::string_view const category) : m_category(category.empty() ? "unknown" : category)
 	{
-		Instance::print(message, Context::make(category, Level::eWarn, location));
-	}
-
-	void logger::info(std::string_view category, std::string_view message, SrcLoc const & location)
-	{
-		Instance::print(message, Context::make(category, Level::eInfo, location));
-	}
-
-	void logger::debug(std::string_view category, std::string_view message, SrcLoc const & location)
-	{
-		Instance::print(message, Context::make(category, Level::eDebug, location));
 	}
 } // namespace gen


### PR DESCRIPTION
Whoops, deleted the branch by mistake! 

As decided, source location info has been replaced with variadic arguments to forward to `std::format`.

Close #38.

Comment from @Rinzii on original PR:

> Could we still keep information for verbose logging with the ability to enable it though the Config but instead use something like __ FILE __ over source location? I know __ FILE __ and such is mega C like, but from my understanding its the best way we can handle this problem without source_location. What are your thoughts @karnkaul ?
