### PR TITLE
Update logger to instead select verbose logging at compile time

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -39,6 +39,7 @@ if(PROJECT_NAME STREQUAL CMAKE_PROJECT_NAME)
 endif()
 
 option(GENESIS_ENABLE_EDITOR "Set the runtime to instead build the editor instead of the default" ON)
+option(GENESIS_ENABLE_VERBOSE_LOGGING "Enable verbose logging" OFF)
 option(GENESIS_BUILD_RUNTIME "Build the genesis runtime (else only library)" ON)
 option(GENESIS_BUILD_GAME "Build the genesis game" ON)
 option(GENESIS_BUILD_SHADERS "Build the genesis shaders" ON)

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -44,6 +44,15 @@
       }
     },
     {
+      "name": "ninja-verbose-logging",
+      "description": "Build configuration using Ninja Multi-config / verbose logging enabled",
+      "inherits": "default",
+      "binaryDir": "${sourceDir}/out/verbose",
+      "cacheVariables": {
+        "GENESIS_ENABLE_VERBOSE_LOGGING": "ON"
+      }
+    },
+    {
       "name": "vs19",
       "description": "Build configuration using Visual Studio 16 (2019)",
       "generator": "Visual Studio 16 2019",

--- a/editor/src/main.cpp
+++ b/editor/src/main.cpp
@@ -15,9 +15,6 @@ int main()
 {
 	// TODO: Make this be set by a config file.
 	auto config = gen::logger::Config{};
-#ifdef GEN_DEBUG
-	config.verbose = true;
-#endif
 
 	// Required to initialize the logger for the application. This must also stay outside the try/catch block.
 	auto logger = gen::logger::Instance{logFile, config};

--- a/engine/CMakeLists.txt
+++ b/engine/CMakeLists.txt
@@ -14,6 +14,10 @@ target_compile_definitions(genesis
         $<$<CONFIG:Release>:GEN_NDEBUG>
         )
 
+if(GENESIS_ENABLE_VERBOSE_LOGGING)
+  target_compile_definitions(genesis PUBLIC GEN_VERBOSE_LOGGING)
+endif()
+
 if (GENESIS_ENABLE_SIMD)
   # This create an internal definition that allows our project to check if it can use simd.
   # If the code decides it can then GEN_SIMD will be defined along with a bunch of other SIMD related defines.

--- a/engine/include/gen/logger/config.hpp
+++ b/engine/include/gen/logger/config.hpp
@@ -52,7 +52,7 @@ namespace gen::logger
 		///  file: file name
 		///  line: line number
 		///
-		static constexpr std::string_view verbose_format_v{"[{level}][T{thread}] [{category}] {message} [{timestamp}] [F: {func}] [{file}:{line}]"};
+		static constexpr std::string_view verbose_format_v{"[{level}][T{thread}] [{category}] {message} [{timestamp}] [F:{func}] [{file}:{line}]"};
 
 		static constexpr std::size_t format_size_v{128};
 
@@ -83,10 +83,5 @@ namespace gen::logger
 		/// \brief Timestamp mode.
 		///
 		Timestamp timestamp{Timestamp::eLocal};
-
-		///
-		/// \brief Whether to print verbose logging information.
-		///
-		bool verbose{false};
 	};
 } // namespace gen::logger

--- a/engine/src/logger/instance.cpp
+++ b/engine/src/logger/instance.cpp
@@ -258,16 +258,9 @@ namespace gen::logger
 				return all_v;
 			}();
 
-			if (config.verbose)
-			{
-				// verbose logging is enabled, override the format
-				config.format = Config::verbose_format_v;
-			}
-			else
-			{
-				// verbose logging is disabled, set the format back to default.
-				config.format = Config::default_format_v;
-			}
+#ifdef GEN_VERBOSE_LOGGING
+			config.format = Config::verbose_format_v;
+#endif
 
 			auto const data = Formatter::Data{.format = config.format, .timestamp = config.timestamp};
 			// cache this for later use


### PR DESCRIPTION
Changed the update logger to no longer allow run time configuration of verbose logging, but instead to only allow this to be defined at compile time by the developer.